### PR TITLE
Decouples github readme from readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 🦆🦆 Don't duck that QC thingy 🦆🦆
 
 
-> **_NOTE:_**  In the past life, QuaC repo used to live at [UAB
+> **_NOTE:_**  In a past life, QuaC used a different remote Git management provider, [UAB
 > Gitlab](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/public/quac). It was migrated to
 > Github in Jan 2023, and the Gitlab version has been archived.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In summary, QuaC performs the following:
 - Runs several QC tools using `BAM` and `VCF` files as input. At our center CGDS, these files are produced as part of
   the [small variant caller
   pipeline](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/sciops/pipelines/small_variant_caller_pipeline).
-- Using [QuaC-Watch](./quac_watch.md) tool, it performs QC checkup based on the expected thresholds for certain QC metrics and summarizes
+- Using [QuaC-Watch](./docs/quac_watch.md) tool, it performs QC checkup based on the expected thresholds for certain QC metrics and summarizes
   the results for easier human consumption
 - Aggregates QC output as well as QuaC-Watch output using MulitQC, both at the sample level and project level.
 - Optionally, above mentioned QuaC-Watch and QC aggregation steps can accept pre-run results from few QC tools (fastqc,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Snakemake](https://img.shields.io/badge/snakemake-6.0.5-brightgreen.svg?style=flat)](https://snakemake.readthedocs.io)
+[![ReadTheDocs](https://readthedocs.org/projects/quac/badge/?version=latest)](https://quac.readthedocs.io/en/stable/)
+
 
 # QuaC
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 !!! Note
 
     In the past life, QuaC repo used to live at [UAB
-    Gitlab](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/sciops/pipelines/quac). It was
+    Gitlab](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/public/quac). It was
     migrated to Github in Jan 2023, and the Gitlab version has been archived.
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Snakemake](https://img.shields.io/badge/snakemake-≥5.6.0-brightgreen.svg?style=flat)](https://snakemake.readthedocs.io)
+
 # QuaC
 
 🦆🦆 Don't duck that QC thingy 🦆🦆

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Full documentation, including installation and how to run QuaC, is available at 
 
 * **Mana**valan Gajapathy
 
+
 ## License
 
 [GNU GPLv3](./LICENSE)
+
+
+## Contributing
+
+See [here](./docs/CONTRIBUTING.md) contributing guidelines.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Snakemake](https://img.shields.io/badge/snakemake-≥5.6.0-brightgreen.svg?style=flat)](https://snakemake.readthedocs.io)
+[![Snakemake](https://img.shields.io/badge/snakemake-6.0.5-brightgreen.svg?style=flat)](https://snakemake.readthedocs.io)
 
 # QuaC
 

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Full documentation, including installation and how to run QuaC, is available at 
 
 ## Contributing
 
-See [here](./docs/CONTRIBUTING.md) contributing guidelines.
+See [here](./docs/CONTRIBUTING.md) for contributing guidelines.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 🦆🦆 Don't duck that QC thingy 🦆🦆
 
 
-!!! Note
-
-    In the past life, QuaC repo used to live at [UAB
-    Gitlab](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/public/quac). It was
-    migrated to Github in Jan 2023, and the Gitlab version has been archived.
+> **_NOTE:_**  In the past life, QuaC repo used to live at [UAB
+> Gitlab](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/public/quac). It was migrated to
+> Github in Jan 2023, and the Gitlab version has been archived.
 
 
 ## What is QuaC?
@@ -27,53 +25,8 @@ In summary, QuaC performs the following:
    fastq-screen, picard's markduplicates) when run with flag `--include_prior_qc`. 
 
 
-!!! note "CGDS users only"
-
-     * At CGDS, BAM and VCF files produced by the 
-     [small variant caller pipeline](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/sciops/pipelines/small_variant_caller_pipeline) 
-     are used as input to QuaC.
-     * Tools fastqc, fastq-screen, and picard's markduplicates, whose output are accepted by QuaC when used with 
-     flag `--include_prior_qc`, are produced by this small_variant_caller_pipeline.
-
-!!! info
-
-    QuaC is built to use with Human WGS/WES data. If you would like to use it with non-human data, please modify the pipeline as needed -- especially the thresholds used in QuaC-Watch configs.
-
-
-## QC tools 
-
-### Tools run by QuaC
-
-QuaC quacks using the tools listed below:
-
-| Tool                                                                                                                       | Use                                                                                                     | QC Type                                  |
-| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| [Qualimap](http://qualimap.conesalab.org/)                                                                                 | Summarizes several alignment metrics using BAM file                                                     | BAM quality                              |
-| [Picard-CollectMultipleMetrics](https://broadinstitute.github.io/picard/command-line-overview.html#CollectMultipleMetrics) | Summarizes alignment metrics from BAM file using several modules                                        | BAM quality                              |
-| [Picard-CollectWgsMetrics](https://broadinstitute.github.io/picard/command-line-overview.html#CollectWgsMetrics)           | Collects metrics about coverage and performance using BAM file                                          | BAM quality                              |
-| [mosdepth](https://github.com/brentp/mosdepth)                                                                             | Fast alignment depth calculation using BAM file                                                         | BAM quality                              |
-| [indexcov](https://github.com/brentp/goleft/tree/master/indexcov)                                                          | Estimate coverage from BAM index for GS <br />(*Skipped in exome mode*)                                 | BAM quality                              |
-| [covviz](https://github.com/brwnj/covviz)                                                                                  | Identifies large, coverage-based anomalies for GS using Indexcov output <br />(*Skipped in exome mode*) | BAM quality                              |
-| [bcftools stats](https://samtools.github.io/bcftools/bcftools.html#stats)                                                  | Summarizes VCF file stats                                                                               | VCF quality                              |
-| [verifybamid](https://github.com/Griffan/VerifyBamID)                                                                      | Estimates within-species (i.e., cross-sample) contamination using BAM file                              | Within-species contamination             |
-| [somalier](https://github.com/brentp/somalier)                                                                             | Estimation of sex, ancestry and relatedness using BAM file                                              | Sex, ancestry and relatedness estimation |
-
-
-### Optional QC output consumed by QuaC
-
-Optionally QuaC can also utilize QC results produced by the tools listed below when run with flag `--include_prior_qc`.
-
-
-| Tool                                                                                                         | Use                                               | QC Type       |
-| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- | ------------- |
-| [fastqc](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)                                         | Performs QC on raw sequence reads data (FASTQ)    | FASTQ quality |
-| [FastQ Screen](https://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/)                             | Screens FASTQ for other-species contamination     | FASTQ quality |
-| [Picard's MarkDuplicates](https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicates) | Determines level of read duplication on BAM files | BAM quality   |
-
-
-!!! note "CGDS users only"
-
-     * At CGDS, these optional tools were run by our small_variant_caller_pipeline.
+> **_NOTE:_**  QuaC is built to use with Human WGS/WES data. If you would like to use it with non-human data, please
+> modify the pipeline as needed -- especially the thresholds used in QuaC-Watch configs.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -38,3 +38,6 @@ Full documentation, including installation and how to run QuaC, is available at 
 
 * **Mana**valan Gajapathy
 
+## License
+
+[GNU GPLv3](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -51,3 +51,8 @@ Full documentation, including installation and how to run QuaC, is available at 
 ## Contributing
 
 See [here](./docs/CONTRIBUTING.md) for contributing guidelines.
+
+
+## Changelog
+
+See [here](./docs/Changelog.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-:grin: :tada: Thank you for taking the time to contribute! :grin: :tada:
+😁 🎉 Thank you for taking the time to contribute! 😁 🎉
 
 The following is a set of guidelines for contributing to QuaC.
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,11 @@ YYYY-MM-DD  John Doe
 ```
 ---
 
+2023-03-01  Manavalan Gajapathy
+
+* Decouples readme.md from readthedocs setup
+
+
 2023-02-28  Manavalan Gajapathy
 
 * Adds license

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 
 !!! Note
 
-    In the past life, QuaC repo used to live at [UAB
+    In a past life, QuaC used a different remote Git management provider, [UAB
     Gitlab](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/public/quac). It was
     migrated to Github in Jan 2023, and the Gitlab version has been archived.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,77 @@
-{!README.md!}
+# QuaC
+
+🦆🦆 Don't duck that QC thingy 🦆🦆
+
+
+!!! Note
+
+    In the past life, QuaC repo used to live at [UAB
+    Gitlab](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/public/quac). It was
+    migrated to Github in Jan 2023, and the Gitlab version has been archived.
+
+
+## What is QuaC?
+
+QuaC is a snakemake-based pipeline that runs several QC tools for WGS/WES samples and then summarizes their results
+using pre-defined, configurable QC thresholds.
+
+In summary, QuaC performs the following:
+
+- Runs several QC tools using `BAM` and `VCF` files as input. At our center CGDS, these files are produced as part of
+  the [small variant caller
+  pipeline](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/sciops/pipelines/small_variant_caller_pipeline).
+- Using [QuaC-Watch](./quac_watch.md) tool, it performs QC checkup based on the expected thresholds for certain QC metrics and summarizes
+  the results for easier human consumption
+- Aggregates QC output as well as QuaC-Watch output using MulitQC, both at the sample level and project level.
+- Optionally, above mentioned QuaC-Watch and QC aggregation steps can accept pre-run results from few QC tools (fastqc,
+   fastq-screen, picard's markduplicates) when run with flag `--include_prior_qc`. 
+
+
+!!! note "CGDS users only"
+
+     * At CGDS, BAM and VCF files produced by the 
+     [small variant caller pipeline](https://gitlab.rc.uab.edu/center-for-computational-genomics-and-data-science/sciops/pipelines/small_variant_caller_pipeline) 
+     are used as input to QuaC.
+     * Tools fastqc, fastq-screen, and picard's markduplicates, whose output are accepted by QuaC when used with 
+     flag `--include_prior_qc`, are produced by this small_variant_caller_pipeline.
+
+!!! info
+
+    QuaC is built to use with Human WGS/WES data. If you would like to use it with non-human data, please modify the pipeline as needed -- especially the thresholds used in QuaC-Watch configs.
+
+
+## QC tools 
+
+### Tools run by QuaC
+
+QuaC quacks using the tools listed below:
+
+| Tool                                                                                                                       | Use                                                                                                     | QC Type                                  |
+| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| [Qualimap](http://qualimap.conesalab.org/)                                                                                 | Summarizes several alignment metrics using BAM file                                                     | BAM quality                              |
+| [Picard-CollectMultipleMetrics](https://broadinstitute.github.io/picard/command-line-overview.html#CollectMultipleMetrics) | Summarizes alignment metrics from BAM file using several modules                                        | BAM quality                              |
+| [Picard-CollectWgsMetrics](https://broadinstitute.github.io/picard/command-line-overview.html#CollectWgsMetrics)           | Collects metrics about coverage and performance using BAM file                                          | BAM quality                              |
+| [mosdepth](https://github.com/brentp/mosdepth)                                                                             | Fast alignment depth calculation using BAM file                                                         | BAM quality                              |
+| [indexcov](https://github.com/brentp/goleft/tree/master/indexcov)                                                          | Estimate coverage from BAM index for GS <br />(*Skipped in exome mode*)                                 | BAM quality                              |
+| [covviz](https://github.com/brwnj/covviz)                                                                                  | Identifies large, coverage-based anomalies for GS using Indexcov output <br />(*Skipped in exome mode*) | BAM quality                              |
+| [bcftools stats](https://samtools.github.io/bcftools/bcftools.html#stats)                                                  | Summarizes VCF file stats                                                                               | VCF quality                              |
+| [verifybamid](https://github.com/Griffan/VerifyBamID)                                                                      | Estimates within-species (i.e., cross-sample) contamination using BAM file                              | Within-species contamination             |
+| [somalier](https://github.com/brentp/somalier)                                                                             | Estimation of sex, ancestry and relatedness using BAM file                                              | Sex, ancestry and relatedness estimation |
+
+
+### Optional QC output consumed by QuaC
+
+Optionally QuaC can also utilize QC results produced by the tools listed below when run with flag `--include_prior_qc`.
+
+
+| Tool                                                                                                         | Use                                               | QC Type       |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- | ------------- |
+| [fastqc](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/)                                         | Performs QC on raw sequence reads data (FASTQ)    | FASTQ quality |
+| [FastQ Screen](https://www.bioinformatics.babraham.ac.uk/projects/fastq_screen/)                             | Screens FASTQ for other-species contamination     | FASTQ quality |
+| [Picard's MarkDuplicates](https://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicates) | Determines level of read duplication on BAM files | BAM quality   |
+
+
+!!! note "CGDS users only"
+
+     * At CGDS, these optional tools were run by our small_variant_caller_pipeline.
+

--- a/docs/input_output.md
+++ b/docs/input_output.md
@@ -2,10 +2,13 @@
 
 ## Input
 
+<!-- markdown-link-check-disable -->
+
 Samples belonging to a project are provided as input via `--pedigree` to QuaC in [pedigree file
 format](https://gatk.broadinstitute.org/hc/en-us/articles/360035531972-PED-Pedigree-format). Only the samples that are
 supplied in pedigree file will be processed by QuaC and all of these samples must belong to the same project.
 
+<!-- markdown-link-check-enable -->
 
 !!! note "CGDS users only"
 


### PR DESCRIPTION
# Pull request

This PR decouples github readme.md doc from readthedocs. This allows to remove breaking links and provides a cleaner look to github readme.

Please fill in the checklist below and comment as needed.

- [x ] Was code modified? Briefly describe. _No_
- [x] Was documentation modified? Briefly describe. _Yes, restructured a bit to decouple readme from readthedocs setup_
- [x] Is this a bug-fix? Briefly describe. _Kinda. Fixes broken hyperlinks in docs_
- [x ] Is this a feature addition? Briefly describe. _No_
- [x] Did you modify QuaC-Watch config file? If so, did you modify multiqc template
  `configs/multiqc_config_template.jinja2` and script `src/quac_watch/create_mutliqc_configs.py` as necessary? _No_
- [x] Did you perform system-level testing manually as described in master readme doc? Did it pass completely? If not why? _No. No code changes made._
- [x] Updated `Changelog.md` file with change logs in recommended format? _Yes_


## Anything else reviewer should know?

No