### PR TITLE
Autocreate user-provided dirpath if they don't exist

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,12 @@ YYYY-MM-DD  John Doe
 ```
 ---
 
+2023-04-04  Manavalan Gajapathy
+
+* Retires use of cheaha-specific env variable $USER_SCRATCH
+* Auto-creates user-provided dir structures for `--outdir`, `--tmp_dir`, and `--log_dir`
+
+
 2023-03-01  Manavalan Gajapathy
 
 * Decouples readme.md from readthedocs setup

--- a/docs/input_output.md
+++ b/docs/input_output.md
@@ -96,7 +96,7 @@ Refer to system testing directory `.test/` in the repo for an example project to
 ## Output
 
 QuaC results are stored at the path specified via option `--outdir` (default:
-`$USER_SCRATCH/tmp/quac/results/test_project/analysis`).  Refer to the [system testing's output](./system_testing.md) to
+`data/quac/results/test_project/analysis`).  Refer to the [system testing's output](./system_testing.md) to
 learn more about the output directory structure. 
 
 !!! tip 

--- a/docs/quac_cli.md
+++ b/docs/quac_cli.md
@@ -33,9 +33,9 @@ QuaC workflow options:
   --workflow_config     YAML config path specifying filepath to dependencies
                         of tools used in QuaC (default: configs/workflow.yaml)
   --outdir              Out directory path (default:
-                        $USER_SCRATCH/tmp/quac/results/test_project/analysis)
+                        data/quac/results/test_project/analysis)
   --tmp_dir             Directory path to store temporary files created by the
-                        workflow (default: $USER_SCRATCH/tmp/quac/tmp)
+                        workflow (default: data/quac/tmp)
   --exome               Flag to run the workflow in exome mode. WARNING:
                         Please provide appropriate configs via
                         --quac_watch_config. (default: False)
@@ -54,7 +54,7 @@ QuaC wrapper options:
                         jobs in cluster. (default: quac/configs/cluster_config.json)
   --log_dir             Directory path where logs (both workflow's and
                         wrapper's) will be stored (default:
-                        $USER_SCRATCH/tmp/quac/logs)
+                        data/quac/logs)
   -e , --extra_args     Pass additional custom args to snakemake. Equal symbol
                         is needed for assignment as in this example: -e='--
                         forceall' (default: None)

--- a/docs/quac_cli.md
+++ b/docs/quac_cli.md
@@ -23,8 +23,7 @@ optional arguments:
 QuaC workflow options:
   --project_name        Project name (default: None)
   --projects_path       Path where all projects are hosted. Do not include
-                        project name here. (default:
-                        /data/project/worthey_lab/projects/)
+                        project name here. (default: None)
   --pedigree            Pedigree filepath. Must correspond to the project
                         supplied via --project_name (default: None)
   --quac_watch_config   YAML config path specifying QC thresholds for QuaC-

--- a/docs/reqts_configs.md
+++ b/docs/reqts_configs.md
@@ -74,7 +74,7 @@ python src/run_quac.py \
       --project_name test_project \
       --projects_path ".test/ngs-data/" \
       --pedigree ".test/configs/${PRIOR_QC_STATUS}/${PROJECT_CONFIG}.ped" \
-      --outdir "$USER_SCRATCH/tmp/quac/results/test_${PROJECT_CONFIG}_exome-${PRIOR_QC_STATUS}/analysis" \
+      --outdir "data/quac/results/test_${PROJECT_CONFIG}_exome-${PRIOR_QC_STATUS}/analysis" \
       --quac_watch_config "configs/quac_watch/exome_quac_watch_config.yaml" \
       --exome \
       $USE_SLURM \

--- a/docs/system_testing.md
+++ b/docs/system_testing.md
@@ -45,7 +45,7 @@ python src/run_quac.py \
       --project_name test_project \
       --projects_path ".test/ngs-data/" \
       --pedigree ".test/configs/${PRIOR_QC_STATUS}/${PROJECT_CONFIG}.ped" \
-      --outdir "$USER_SCRATCH/tmp/quac/results/test_${PROJECT_CONFIG}_wgs-${PRIOR_QC_STATUS}/analysis" \
+      --outdir "data/quac/results/test_${PROJECT_CONFIG}_wgs-${PRIOR_QC_STATUS}/analysis" \
       --quac_watch_config "configs/quac_watch/wgs_quac_watch_config.yaml" \
       --workflow_config "configs/workflow.yaml" \
       $USE_SLURM
@@ -55,7 +55,7 @@ python src/run_quac.py \
       --project_name test_project \
       --projects_path ".test/ngs-data/" \
       --pedigree ".test/configs/${PRIOR_QC_STATUS}/${PROJECT_CONFIG}.ped" \
-      --outdir "$USER_SCRATCH/tmp/quac/results/test_${PROJECT_CONFIG}_exome-${PRIOR_QC_STATUS}/analysis" \
+      --outdir "data/quac/results/test_${PROJECT_CONFIG}_exome-${PRIOR_QC_STATUS}/analysis" \
       --quac_watch_config "configs/quac_watch/exome_quac_watch_config.yaml" \
       --workflow_config "configs/workflow.yaml" \
       --exome \
@@ -71,7 +71,7 @@ python src/run_quac.py \
       --project_name test_project \
       --projects_path ".test/ngs-data/" \
       --pedigree ".test/configs/${PRIOR_QC_STATUS}/${PROJECT_CONFIG}.ped" \
-      --outdir "$USER_SCRATCH/tmp/quac/results/test_${PROJECT_CONFIG}_wgs-${PRIOR_QC_STATUS}/analysis" \
+      --outdir "data/quac/results/test_${PROJECT_CONFIG}_wgs-${PRIOR_QC_STATUS}/analysis" \
       --quac_watch_config "configs/quac_watch/wgs_quac_watch_config.yaml" \
       --include_prior_qc \
       --allow_sample_renaming \
@@ -83,7 +83,7 @@ python src/run_quac.py \
       --project_name test_project \
       --projects_path ".test/ngs-data/" \
       --pedigree ".test/configs/${PRIOR_QC_STATUS}/${PROJECT_CONFIG}.ped" \
-      --outdir "$USER_SCRATCH/tmp/quac/results/test_${PROJECT_CONFIG}_exome-${PRIOR_QC_STATUS}/analysis" \
+      --outdir "data/tmp/quac/results/test_${PROJECT_CONFIG}_exome-${PRIOR_QC_STATUS}/analysis" \
       --quac_watch_config "configs/quac_watch/exome_quac_watch_config.yaml" \
       --exome \
       --include_prior_qc \
@@ -101,8 +101,8 @@ python src/run_quac.py \
 Output directory structure for WGS + `include_prior_qc` mode would look like this.
 
 ```sh
-$ tree -d $USER_SCRATCH/tmp/quac/results/test_project_2samples_wgs-no_priorQC/ -L 5
-$USER_SCRATCH/tmp/quac/results/test_project_2samples_wgs-no_priorQC/
+$ tree -d data/quac/results/test_project_2samples_wgs-no_priorQC/ -L 5
+data/quac/results/test_project_2samples_wgs-no_priorQC/
 └── analysis
     ├── C
     │   └── qc

--- a/docs/system_testing.md
+++ b/docs/system_testing.md
@@ -83,7 +83,7 @@ python src/run_quac.py \
       --project_name test_project \
       --projects_path ".test/ngs-data/" \
       --pedigree ".test/configs/${PRIOR_QC_STATUS}/${PROJECT_CONFIG}.ped" \
-      --outdir "data/tmp/quac/results/test_${PROJECT_CONFIG}_exome-${PRIOR_QC_STATUS}/analysis" \
+      --outdir "data/quac/results/test_${PROJECT_CONFIG}_exome-${PRIOR_QC_STATUS}/analysis" \
       --quac_watch_config "configs/quac_watch/exome_quac_watch_config.yaml" \
       --exome \
       --include_prior_qc \

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -232,11 +232,11 @@ def is_valid_dir(p, arg):
 
 def create_dirpath(arg):
     dpath = get_full_path(os.path.expandvars(arg))
-    if not dpath.is_dir():
+    if not Path(dpath).is_dir():
         make_dir(dpath)
         print(f"Created directory: {dpath}")
 
-    return None
+    return dpath
 
 
 if __name__ == "__main__":
@@ -289,7 +289,7 @@ if __name__ == "__main__":
         "--outdir",
         help="Out directory path",
         default=QUAC_OUTDIR_DEFAULT,
-        type=lambda x: create_dirpath(PARSER, x),
+        type=lambda x: create_dirpath(x),
         metavar="",
     )
     TMPDIR_DEFAULT = "data/quac/tmp"
@@ -297,7 +297,7 @@ if __name__ == "__main__":
         "--tmp_dir",
         help="Directory path to store temporary files created by the workflow",
         default=TMPDIR_DEFAULT,
-        type=lambda x: create_dirpath(PARSER, x),
+        type=lambda x: create_dirpath(x),
         metavar="",
     )
     WORKFLOW.add_argument(
@@ -339,7 +339,7 @@ if __name__ == "__main__":
         "--log_dir",
         help="Directory path where logs (both workflow's and wrapper's) will be stored",
         default=LOGS_DIR_DEFAULT,
-        type=lambda x: create_dirpath(PARSER, x),
+        type=lambda x: create_dirpath(x),
         metavar="",
     )
     WRAPPER.add_argument(

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -253,12 +253,9 @@ if __name__ == "__main__":
         help="Project name",
         metavar="",
     )
-
-    PROJECT_PATH_DEFAULT = "/data/project/worthey_lab/projects/"
     WORKFLOW.add_argument(
         "--projects_path",
         help="Path where all projects are hosted. Do not include project name here.",
-        default=PROJECT_PATH_DEFAULT,
         type=lambda x: is_valid_dir(PARSER, x),
         metavar="",
     )
@@ -386,6 +383,10 @@ if __name__ == "__main__":
     if not ARGS.quac_watch_config:
         raise SystemExit(
             "Error. Quac-watch config is missing. Please supply using --quac_watch_config."
+        )
+    if not ARGS.projects_path:
+        raise SystemExit(
+            "Error. 'Projects path' not provided. Please supply using --projects_path."
         )
 
     main(ARGS)

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -30,7 +30,7 @@ def make_dir(d):
 
 def read_workflow_config(workflow_config_fpath):
     """
-    Read workflow config file to 
+    Read workflow config file to
     (1) identify paths to be mounted for singularity.
     (2) get slurm partitions.
     """
@@ -50,7 +50,7 @@ def read_workflow_config(workflow_config_fpath):
     # verifyBamID resource files
     for resource in datasets["verifyBamID"]:
         mount_paths.add(Path(datasets["verifyBamID"][resource]).parent)
-        
+
     # get slurm partitions
     slurm_partitions_dict = data["slurm_partitions"]
 
@@ -58,7 +58,13 @@ def read_workflow_config(workflow_config_fpath):
 
 
 def gather_mount_paths(
-    projects_path, project_name, pedigree_path, out_dir, log_dir, quac_watch_config, workflow_config
+    projects_path,
+    project_name,
+    pedigree_path,
+    out_dir,
+    log_dir,
+    quac_watch_config,
+    workflow_config,
 ):
     """
     Returns paths that need to be mounted to singularity
@@ -140,7 +146,7 @@ def create_snakemake_command(args, repo_path, mount_paths):
             "--cluster 'sbatch --ntasks {cluster.ntasks} --partition {cluster.partition}"
             " --cpus-per-task {cluster.cpus-per-task} --mem-per-cpu {cluster.mem-per-cpu}"
             " --job-name {cluster.jobname} --output {cluster.output} --parsable'",
-        ]        
+        ]
 
     # add any user provided extra args for snakemake
     if args.extra_args:
@@ -185,7 +191,7 @@ def main(args):
     _, slurm_partition_times = read_workflow_config(args.workflow_config)
 
     slurm_resources = {
-        "partition": args.slurm_partition, 
+        "partition": args.slurm_partition,
         "ntasks": "1",
         "time": slurm_partition_times[args.slurm_partition],
         "cpus-per-task": "1" if args.subtasks_slurm else "4",
@@ -264,8 +270,10 @@ if __name__ == "__main__":
     )
     WORKFLOW.add_argument(
         "--quac_watch_config",
-        help=("YAML config path specifying QC thresholds for QuaC-Watch." 
-              " See directory 'configs/quac_watch/' in quac repo for the included config files."),
+        help=(
+            "YAML config path specifying QC thresholds for QuaC-Watch."
+            " See directory 'configs/quac_watch/' in quac repo for the included config files."
+        ),
         type=lambda x: is_valid_file(PARSER, x),
         metavar="",
     )
@@ -311,7 +319,7 @@ if __name__ == "__main__":
         "--subtasks_slurm",
         action="store_true",
         help="Flag indicating that the main Snakemake process of QuaC should submit subtasks of"
-        " the workflow as Slurm jobs instead of running them on the same machine as itself"
+        " the workflow as Slurm jobs instead of running them on the same machine as itself",
     )
 
     ############ Args for QuaC wrapper tool  ############
@@ -351,9 +359,9 @@ if __name__ == "__main__":
     WRAPPER.add_argument(
         "--snakemake_slurm",
         action="store_true",
-        help="Flag indicating that the main Snakemake process of QuaC should be" 
-        " submitted to run in a Slurm job instead of executing in the current" 
-        " environment. Useful for headless execution on Slurm-based HPC systems."
+        help="Flag indicating that the main Snakemake process of QuaC should be"
+        " submitted to run in a Slurm job instead of executing in the current"
+        " environment. Useful for headless execution on Slurm-based HPC systems.",
     )
     RERUN_FAILED_DEFAULT = 1
     WRAPPER.add_argument(
@@ -373,9 +381,11 @@ if __name__ == "__main__":
     )
 
     ARGS = PARSER.parse_args()
-    
+
     # Didn't find a argparse friendly solution without having to refactor. Good enough solution
     if not ARGS.quac_watch_config:
-        raise SystemExit("Error. Quac-watch config is missing. Please supply using --quac_watch_config.")
+        raise SystemExit(
+            "Error. Quac-watch config is missing. Please supply using --quac_watch_config."
+        )
 
     main(ARGS)

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -276,7 +276,7 @@ if __name__ == "__main__":
         type=lambda x: is_valid_file(PARSER, x),
         metavar="",
     )
-    QUAC_OUTDIR_DEFAULT = "$USER_SCRATCH/tmp/quac/results/test_project/analysis"
+    QUAC_OUTDIR_DEFAULT = "data/quac/results/test_project/analysis"
     WORKFLOW.add_argument(
         "--outdir",
         help="Out directory path",
@@ -284,7 +284,7 @@ if __name__ == "__main__":
         type=lambda x: create_dirpath(PARSER, x),
         metavar="",
     )
-    TMPDIR_DEFAULT = "$USER_SCRATCH/tmp/quac/tmp"
+    TMPDIR_DEFAULT = "data/quac/tmp"
     WORKFLOW.add_argument(
         "--tmp_dir",
         help="Directory path to store temporary files created by the workflow",
@@ -326,7 +326,7 @@ if __name__ == "__main__":
         metavar="",
     )
 
-    LOGS_DIR_DEFAULT = f"$USER_SCRATCH/tmp/quac/logs"
+    LOGS_DIR_DEFAULT = f"data/quac/logs"
     WRAPPER.add_argument(
         "--log_dir",
         help="Directory path where logs (both workflow's and wrapper's) will be stored",

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -224,6 +224,15 @@ def is_valid_dir(p, arg):
         return get_full_path(os.path.expandvars(arg))
 
 
+def create_dirpath(arg):
+    dpath = get_full_path(os.path.expandvars(arg))
+    if not dpath.is_dir():
+        make_dir(dpath)
+        print(f"Created directory: {dpath}")
+
+    return None
+
+
 if __name__ == "__main__":
     PARSER = argparse.ArgumentParser(
         description="Command line interface to QuaC pipeline.",
@@ -272,7 +281,7 @@ if __name__ == "__main__":
         "--outdir",
         help="Out directory path",
         default=QUAC_OUTDIR_DEFAULT,
-        type=lambda x: is_valid_dir(PARSER, x),
+        type=lambda x: create_dirpath(PARSER, x),
         metavar="",
     )
     TMPDIR_DEFAULT = "$USER_SCRATCH/tmp/quac/tmp"
@@ -280,7 +289,7 @@ if __name__ == "__main__":
         "--tmp_dir",
         help="Directory path to store temporary files created by the workflow",
         default=TMPDIR_DEFAULT,
-        type=lambda x: is_valid_dir(PARSER, x),
+        type=lambda x: create_dirpath(PARSER, x),
         metavar="",
     )
     WORKFLOW.add_argument(
@@ -322,7 +331,7 @@ if __name__ == "__main__":
         "--log_dir",
         help="Directory path where logs (both workflow's and wrapper's) will be stored",
         default=LOGS_DIR_DEFAULT,
-        type=lambda x: is_valid_dir(PARSER, x),
+        type=lambda x: create_dirpath(PARSER, x),
         metavar="",
     )
     WRAPPER.add_argument(


### PR DESCRIPTION
# Pull request

External users (JOSS reviewers for example) have run into difficulties due to 

* Use of environment variable `$USER_SCRATCH`, which appears not to be universal even among SLURM environments and instead is Cheaha specific.
* QuaC not auto-creating directories and instead forcing users to create them.
     * This was a deliberate choice made for CGDS's use-case, but this results in confusion among external users.

Source: #66, https://github.com/openjournals/joss-reviews/issues/5313#issuecomment-1490213554

**Solutions implemented:**

* Completely retired `$USER_SCRATCH`. It was replaced with `data/`
* If user-provided directories for args `--outdir`, `--tmp_dir`, and `--log_dir` are missing, I have now refactored to auto-create them. 


Please fill in the checklist below and comment as needed.

- [x] Was code modified? Briefly describe. _Yes. See above_
- [x] Was documentation modified? Briefly describe. _Yes. Docs are updated to reflect above-mentioned refactoring_
- [x] Is this a bug-fix? Briefly describe. _No. This is an enhancement_
- [x] Is this a feature addition? Briefly describe. _No_
- [x] Did you modify QuaC-Watch config file? If so, did you modify multiqc template _Not modified_
  `configs/multiqc_config_template.jinja2` and script `src/quac_watch/create_mutliqc_configs.py` as necessary?
- [x] Did you perform system-level testing manually as described in master readme doc? Did it pass completely? If not why?
- [x] Updated `Changelog.md` file with change logs in recommended format?


## Anything else reviewer should know?

closes #66