### PR TITLE
Check mount paths exist

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -15,7 +15,7 @@ YYYY-MM-DD  John Doe
 2023-05-09  Manavalan Gajapathy
 
 * Adds a verification step in the CLI wrapper script to check if the file/dirpaths to be mounted to singularity already exist as expected (#71)
-
+* Resolves dirpaths of datasets in the workflow config file to obtain their full path
 
 2023-04-10  Manavalan Gajapathy
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -12,6 +12,11 @@ YYYY-MM-DD  John Doe
 ```
 ---
 
+2023-05-09  Manavalan Gajapathy
+
+* Adds a verification step in the CLI wrapper script to check if the file/dirpaths to be mounted to singularity already exist as expected (#71)
+
+
 2023-04-10  Manavalan Gajapathy
 
 * Refactors snakemake pipeline to fully run jobs in direct singularity containers. No more creation of conda environment using singularity containers! (#69)

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -61,15 +61,15 @@ def read_workflow_config(workflow_config_fpath):
     mount_paths = set()
     datasets = data["datasets"]
     # ref genome
-    mount_paths.add(Path(datasets["ref"]).parent)
+    mount_paths.add(Path(get_full_path(datasets["ref"])).parent)
 
     # somalier resource files
     for resource in datasets["somalier"]:
-        mount_paths.add(Path(datasets["somalier"][resource]).parent)
+        mount_paths.add(Path(get_full_path(datasets["somalier"][resource])).parent)
 
     # verifyBamID resource files
     for resource in datasets["verifyBamID"]:
-        mount_paths.add(Path(datasets["verifyBamID"][resource]).parent)
+        mount_paths.add(Path(get_full_path(datasets["verifyBamID"][resource])).parent)
 
     # get slurm partitions
     slurm_partitions_dict = data["slurm_partitions"]

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -29,11 +29,17 @@ def make_dir(d):
 
 
 def check_path_exists(path):
+    """
+    Ensure input file/dir path exists
+    """
+
+    path = Path(path)
     if not path.exists():
         raise SystemExit(
             f"ERROR: Path '{str(path)}' is missing. Please provide a valid path."
         )
-    return path
+        
+    return None
 
 
 def read_workflow_config(workflow_config_fpath):
@@ -49,15 +55,19 @@ def read_workflow_config(workflow_config_fpath):
     mount_paths = set()
     datasets = data["datasets"]
     # ref genome
-    mount_paths.add(check_path_exists(Path(datasets["ref"]).parent))
+    check_path_exists(datasets["ref"])
+    mount_paths.add(Path(datasets["ref"]).parent)
 
     # somalier resource files
     for resource in datasets["somalier"]:
-        mount_paths.add(check_path_exists(Path(datasets["somalier"][resource]).parent))
+        check_path_exists(datasets["somalier"][resource])
+        mount_paths.add(Path(datasets["somalier"][resource]).parent)
 
     # verifyBamID resource files
     for resource in datasets["verifyBamID"]:
-        mount_paths.add(check_path_exists(Path(datasets["verifyBamID"][resource]).parent))
+        # checks only the parent dir as the filepath provided is just a prefix (ie. without extensions)
+        check_path_exists(Path(datasets["verifyBamID"][resource]).parent)
+        mount_paths.add(Path(datasets["verifyBamID"][resource]).parent)
 
     # get slurm partitions
     slurm_partitions_dict = data["slurm_partitions"]
@@ -83,20 +93,23 @@ def gather_mount_paths(
     # project path
     project_path = Path(projects_path) / project_name / "analysis"
     make_dir(project_path)
-    mount_paths.add(check_path_exists(project_path))
+    mount_paths.add(project_path)
 
     # pedigree filepath
-    mount_paths.add(check_path_exists(Path(pedigree_path).parent))
+    check_path_exists(pedigree_path)
+    mount_paths.add(Path(pedigree_path).parent)
 
     # output dirpath
     make_dir(out_dir)
-    mount_paths.add(check_path_exists(out_dir))
+    mount_paths.add(out_dir)
 
     # logs dirpath
-    mount_paths.add(check_path_exists(log_dir))
+    check_path_exists(log_dir)
+    mount_paths.add(log_dir)
 
     # QuaC-Watch configfile
-    mount_paths.add(check_path_exists(quac_watch_config))
+    check_path_exists(quac_watch_config)
+    mount_paths.add(quac_watch_config)
 
     # read paths in workflow config file
     paths_in_wokflow_config, _ = read_workflow_config(workflow_config)

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -28,6 +28,14 @@ def make_dir(d):
     return None
 
 
+def check_path_exists(path):
+    if not path.exists():
+        raise SystemExit(
+            f"ERROR: Path '{str(path)}' is missing. Please provide a valid path."
+        )
+    return path
+
+
 def read_workflow_config(workflow_config_fpath):
     """
     Read workflow config file to
@@ -41,15 +49,15 @@ def read_workflow_config(workflow_config_fpath):
     mount_paths = set()
     datasets = data["datasets"]
     # ref genome
-    mount_paths.add(Path(datasets["ref"]).parent)
+    mount_paths.add(check_path_exists(Path(datasets["ref"]).parent))
 
     # somalier resource files
     for resource in datasets["somalier"]:
-        mount_paths.add(Path(datasets["somalier"][resource]).parent)
+        mount_paths.add(check_path_exists(Path(datasets["somalier"][resource]).parent))
 
     # verifyBamID resource files
     for resource in datasets["verifyBamID"]:
-        mount_paths.add(Path(datasets["verifyBamID"][resource]).parent)
+        mount_paths.add(check_path_exists(Path(datasets["verifyBamID"][resource]).parent))
 
     # get slurm partitions
     slurm_partitions_dict = data["slurm_partitions"]
@@ -75,20 +83,20 @@ def gather_mount_paths(
     # project path
     project_path = Path(projects_path) / project_name / "analysis"
     make_dir(project_path)
-    mount_paths.add(project_path)
+    mount_paths.add(check_path_exists(project_path))
 
     # pedigree filepath
-    mount_paths.add(Path(pedigree_path).parent)
+    mount_paths.add(check_path_exists(Path(pedigree_path).parent))
 
     # output dirpath
     make_dir(out_dir)
-    mount_paths.add(out_dir)
+    mount_paths.add(check_path_exists(out_dir))
 
     # logs dirpath
-    mount_paths.add(log_dir)
+    mount_paths.add(check_path_exists(log_dir))
 
     # QuaC-Watch configfile
-    mount_paths.add(quac_watch_config)
+    mount_paths.add(check_path_exists(quac_watch_config))
 
     # read paths in workflow config file
     paths_in_wokflow_config, _ = read_workflow_config(workflow_config)

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -65,8 +65,9 @@ def read_workflow_config(workflow_config_fpath):
 
     # verifyBamID resource files
     for resource in datasets["verifyBamID"]:
-        # checks only the parent dir as the filepath provided is just a prefix (ie. without extensions)
-        check_path_exists(Path(datasets["verifyBamID"][resource]).parent)
+        # appends file extension to the prefix path and then checks if they exist
+        for extension in ["bed", "mu", "UD", "V"]:
+            check_path_exists(Path(datasets["verifyBamID"][resource] + f".{extension}"))
         mount_paths.add(Path(datasets["verifyBamID"][resource]).parent)
 
     # get slurm partitions

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -114,6 +114,7 @@ def gather_mount_paths(
     paths_in_wokflow_config, _ = read_workflow_config(workflow_config)
     mount_paths.update(paths_in_wokflow_config)
 
+    # checks paths to be mounted to singularity exist
     check_mount_paths_exist(mount_paths)
 
     return ",".join([str(x) for x in mount_paths])

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -182,7 +182,7 @@ def create_snakemake_command(args, repo_path, mount_paths):
 
 def main(args):
 
-    repo_path = Path(__file__).absolute().parents[1]
+    repo_path = Path(get_full_path(__file__)).parents[1]
 
     # process user's input-output config file and get singularity bind paths
     mount_paths = gather_mount_paths(


### PR DESCRIPTION
# Pull request

* Adds a verification step in the CLI wrapper script to check if the file/dirpaths to be mounted to singularity already exist as expected (#71). This would help debugging easier in cases where paths don't exist as expected.
* Resolves dirpaths of datasets in the workflow config file to obtain their full path

Please fill in the checklist below and comment as needed.

- [x] Was code modified? Briefly describe. _Yes. See description_.
- [x] Was documentation modified? Briefly describe. _No._
- [x] Is this a bug-fix? Briefly describe. _No._
- [x] Is this a feature addition? Briefly describe. _Yes. See description_.
- [x] Did you modify QuaC-Watch config file? If so, did you modify multiqc template
  `configs/multiqc_config_template.jinja2` and script `src/quac_watch/create_mutliqc_configs.py` as necessary? _No._
- [x] Did you perform system-level testing manually as described in master readme doc? Did it pass completely? If not why?
- [x] Updated `Changelog.md` file with change logs in recommended format?


## Anything else reviewer should know?
