### PR TITLE
Bug fix: fixes missing fastqc and fastq-screen modules in multiqc reports

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -13,6 +13,10 @@ YYYY-MM-DD  John Doe
 
 ---
 
+2026-03-31  Manavalan Gajapathy
+
+* Bug fix: Fixes missing fastq and fastq_screen modules in final pass multiqc and project level multiqc reports.
+
 2024-07-08  Brandon Wilk
 
 * Makes bug fix for issue #102 to add FASTQ file paths as mounts to containers

--- a/workflow/rules/aggregate_results.smk
+++ b/workflow/rules/aggregate_results.smk
@@ -204,10 +204,18 @@ rule aggregate_sample_rename_configs:
 rule multiqc_aggregation_all_samples:
     input:
         [get_priorQC_filepaths(sample, SAMPLES_CONFIG) for sample in SAMPLES_CONFIG.keys()] if INCLUDE_PRIOR_QC_DATA else [],
+        [OUT_DIR / sample / "qc" / "fastqc-raw" / f"{sample}-{unit}-{read}_fastqc.html" 
+            for sample in SAMPLES_CONFIG 
+            for unit in SAMPLES_CONFIG[sample]["fastq"].keys()
+            for read in ["R1", "R2"]
+            ],
+        [OUT_DIR / sample / "qc" / "fastq_screen-raw" / f"{sample}-{unit}-{read}_screen.txt" 
+            for sample in SAMPLES_CONFIG 
+            for unit in SAMPLES_CONFIG[sample]["fastq"].keys()
+            for read in ["R1", "R2"]
+            ],
         expand(
             [
-                OUT_DIR / "{sample}" / "qc" / "fastqc-raw" / "{sample}-{unit}-{read}_fastqc.html",
-                OUT_DIR / "{sample}" / "qc" / "fastq_screen-raw" / "{sample}-{unit}-{read}_screen.txt",
                 OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "relatedness" / "somalier.html",
                 OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "ancestry" / "somalier.somalier-ancestry.html",
                 OUT_DIR / "{sample}" / "qc" / "samtools-stats" / "{sample}.txt",
@@ -219,8 +227,6 @@ rule multiqc_aggregation_all_samples:
                 OUT_DIR / "{sample}" / "qc" / "quac_watch" / "quac_watch_overall_summary.yaml",
             ],
             sample=SAMPLES,
-            unit=[1],
-            read=["R1", "R2"],
         ),
         multiqc_config=MULTIQC_CONFIG_FILE,
         rename_config=OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "multiqc" / "configs" / "aggregated_rename_configs.tsv",

--- a/workflow/rules/aggregate_results.smk
+++ b/workflow/rules/aggregate_results.smk
@@ -133,9 +133,13 @@ rule quac_watch:
 
 rule multiqc_by_sample_final_pass:
     input:
+        lambda wildcards: expand(OUT_DIR / wildcards.sample / "qc" / "fastqc-raw" / f"{wildcards.sample}-{{unit}}-{{reads}}_fastqc.html", 
+                unit=SAMPLES_CONFIG[wildcards.sample]["fastq"].keys(), 
+                reads=["R1", "R2"]),
+        lambda wildcards: expand(OUT_DIR / wildcards.sample / "qc" / "fastq_screen-raw" / f"{wildcards.sample}-{{unit}}-{{reads}}_screen.txt", 
+                unit=SAMPLES_CONFIG[wildcards.sample]["fastq"].keys(), 
+                reads=["R1", "R2"]),
         lambda wildcards: get_priorQC_filepaths(wildcards.sample, SAMPLES_CONFIG) if INCLUDE_PRIOR_QC_DATA else [],
-        OUT_DIR / "{sample}" / "qc" / "multiqc_initial_pass" / "{sample}_multiqc_data" / "multiqc_fastqc.txt",
-        OUT_DIR / "{sample}" / "qc" / "multiqc_initial_pass" / "{sample}_multiqc_data" / "multiqc_fastq_screen.txt",
         OUT_DIR / "{sample}" / "qc" / "samtools-stats" / "{sample}.txt",
         OUT_DIR / "{sample}" / "qc" / "qualimap" / "{sample}" / "qualimapReport.html",
         OUT_DIR / "{sample}" / "qc" / "picard-stats" / "{sample}.alignment_summary_metrics",
@@ -202,10 +206,10 @@ rule multiqc_aggregation_all_samples:
         [get_priorQC_filepaths(sample, SAMPLES_CONFIG) for sample in SAMPLES_CONFIG.keys()] if INCLUDE_PRIOR_QC_DATA else [],
         expand(
             [
+                OUT_DIR / "{sample}" / "qc" / "fastqc-raw" / "{sample}-{unit}-{read}_fastqc.html",
+                OUT_DIR / "{sample}" / "qc" / "fastq_screen-raw" / "{sample}-{unit}-{read}_screen.txt",
                 OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "relatedness" / "somalier.html",
                 OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "ancestry" / "somalier.somalier-ancestry.html",
-                OUT_DIR / "{sample}" / "qc" / "multiqc_initial_pass" / "{sample}_multiqc_data" / "multiqc_fastqc.txt",
-                OUT_DIR / "{sample}" / "qc" / "multiqc_initial_pass" / "{sample}_multiqc_data" / "multiqc_fastq_screen.txt",
                 OUT_DIR / "{sample}" / "qc" / "samtools-stats" / "{sample}.txt",
                 OUT_DIR / "{sample}" / "qc" / "qualimap" / "{sample}" / "qualimapReport.html",
                 OUT_DIR / "{sample}" / "qc" / "picard-stats" / "{sample}.alignment_summary_metrics",


### PR DESCRIPTION
# Pull request

**Please add a clear description of what the PR is about:**

Brandon came across a bug - Sample-level, final pass multiqc reports as well as project-level multiqc reports were missing fastqc and fastq-screen modules though fastqc and fastq-screen subsections were available as part of its quac-watch section at the top. Issue was because original fastq QC files were not included in their snakemake rules and instead their results from multiqc-first-pass rule was included.  

------

**Please fill in the checklist below and comment as needed:**

- [x] Was code modified? Briefly describe. _Yes. See description above._
- [x] Was documentation modified? Briefly describe. _No_
- [x] Is this a bug-fix? Briefly describe. _Yes. See description above._
- [x] Is this a feature addition? Briefly describe. _No_
- [x] Did you modify QuaC-Watch config file? If so, did you modify multiqc template
  `configs/multiqc_config_template.jinja2` and script `src/quac_watch/create_mutliqc_configs.py` as necessary? _No_
- [x] Did you perform system-level testing manually, using `----cli_cluster_config` and `--snakemake_cluster_config`
  options, as described in the [documentation](https://quac.readthedocs.io/en/stable/system_testing/)? Did it pass
  completely? If not why? _Yes_
- [x] Updated `Changelog.md` file with change logs in recommended format?


## Anything else reviewer should know?
