### PR TITLE
Waits until submitted slurm job terminates

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -13,6 +13,10 @@ YYYY-MM-DD  John Doe
 
 ---
 
+2026-06-04 Manavalan Gajapathy
+
+* Adds `--wait` option to allow waiting until submitted slurm job is terminated
+
 2026-03-31  Manavalan Gajapathy
 
 * Bug fix: Fixes missing fastq and fastq_screen modules in final pass multiqc and project level multiqc reports.

--- a/docs/quac_cli.md
+++ b/docs/quac_cli.md
@@ -67,6 +67,7 @@ QuaC wrapper options:
                         in cluster. Edit template file
                         'configs/cli_cluster_config.json' to suit your SLURM
                         environment. (default: None)
+  --wait                Waits for submitted Slurm jobs to terminate (default: False)
   --log_dir             Directory path where logs (both workflow's and
                         wrapper's) will be stored (default: data/quac/logs)
 ```

--- a/src/run_quac.py
+++ b/src/run_quac.py
@@ -310,6 +310,9 @@ def main(args):
 
         with open(args.cli_cluster_config) as fh:
             slurm_resources = json.load(fh)
+    # if need to wait for the submitted slurm job to terminate
+    if args.wait:
+        slurm_resources["W"] = ""   # relevant - https://github.com/brentp/slurmpy/issues/13#issuecomment-4623873964
 
     job_dict = {
         "basename": "quac-",
@@ -454,6 +457,12 @@ if __name__ == "__main__":
         " Edit template file 'configs/cli_cluster_config.json' to suit your SLURM environment.",
         type=lambda x: is_valid_file(PARSER, x),
         metavar="",
+    )
+
+    WRAPPER.add_argument(
+        "--wait",
+        action="store_true",
+        help="Waits for submitted Slurm jobs to terminate",
     )
 
     LOGS_DIR_DEFAULT = f"data/quac/logs"


### PR DESCRIPTION
# Pull request

**Please add a clear description of what the PR is about:**

Adds `--wait` option. When used, it will wait for the submitted job to be terminated before exiting. This feature is added in favor of Gubernomics - https://github.com/uab-cgds-worthey/Gubernomics/issues/1

------

**Please fill in the checklist below and comment as needed:**

- [x] Was code modified? Briefly describe. _Yes. See above_
- [x] Was documentation modified? Briefly describe. _Yes._
- [x] Is this a bug-fix? Briefly describe. _No_
- [x] Is this a feature addition? Briefly describe. _Yes. See above_
- [x] Did you modify QuaC-Watch config file? If so, did you modify multiqc template
  `configs/multiqc_config_template.jinja2` and script `src/quac_watch/create_mutliqc_configs.py` as necessary? _No_
- [x] Did you perform system-level testing manually, using `----cli_cluster_config` and `--snakemake_cluster_config`
  options, as described in the [documentation](https://quac.readthedocs.io/en/stable/system_testing/)? Did it pass
  completely? If not why? _Yes._
- [x] Updated `Changelog.md` file with change logs in recommended format? _Yes_


## Anything else reviewer should know?
Refer to `Anything else reviewer should know?` section in https://github.com/uab-cgds-worthey/manta_sv_caller_pipeline/pull/21#issue-4590294566. It applies here as well.