### PR TITLE
Remove write protection

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -13,6 +13,10 @@ YYYY-MM-DD  John Doe
 
 ---
 
+2026-06-11 Manavalan Gajapathy
+
+* Removes write protections for project-level output files (#106)
+
 2026-06-04 Manavalan Gajapathy
 
 * Adds `--wait` option to allow waiting until submitted slurm job is terminated

--- a/workflow/rules/aggregate_results.smk
+++ b/workflow/rules/aggregate_results.smk
@@ -182,7 +182,7 @@ rule aggregate_sample_rename_configs:
         expand(OUT_DIR / "{sample}" / "qc" / "multiqc_initial_pass" / "multiqc_sample_rename_config" / "{sample}_rename_config.tsv",
             sample=SAMPLES)
     output:
-        outfile=protected(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "multiqc" / "configs" / "aggregated_rename_configs.tsv"),
+        outfile=OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "multiqc" / "configs" / "aggregated_rename_configs.tsv",
         tempfile=temp(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "multiqc" / "configs" / "flist.txt"),
     message:
         "Aggregate all sample rename-config files."
@@ -231,7 +231,7 @@ rule multiqc_aggregation_all_samples:
         multiqc_config=MULTIQC_CONFIG_FILE,
         rename_config=OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "multiqc" / "configs" / "aggregated_rename_configs.tsv",
     output:
-        protected(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "multiqc" / "multiqc_report.html"),
+        OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "multiqc" / "multiqc_report.html",
     message:
         "Running multiqc for all samples"
     params:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -47,21 +47,19 @@ def read_sample_config(config_f):
 
 
 def is_testing_mode():
-    "checks if testing dataset is used as input for the pipeline"
+    "checks if testing dataset is used as input for the pipeline. Checks in FASTQ filepaths."
 
     query = ".test"
     isTesting = False
     for sample in SAMPLES_CONFIG.values():
-        for fvalue in sample.values():
-            if isinstance(fvalue, str) and query in PurePath(fvalue).parts:
-                isTesting = True
-            else:
-                for fpath in fvalue:
-                    if query in PurePath(fpath).parts:
-                        isTesting = True
+        for lane in sample["fastq"]:
+            for read_pair in sample["fastq"][lane]:
+                if query in PurePath(sample["fastq"][lane][read_pair]).parts:
+                    isTesting = True
+                    break
 
     if isTesting:
-        logger.info(f"// WARNING: '{query}' present in at least one of the filepaths supplied via --sample_config. So testing mode is used.")
+        logger.info(f"// WARNING: '{query}' present in at least one of the FASTQ filepaths supplied via --sample_config. So testing mode is used.")
         return True
 
     return None

--- a/workflow/rules/coverage_analysis.smk
+++ b/workflow/rules/coverage_analysis.smk
@@ -137,7 +137,7 @@ rule mosdepth_plot:
         ),
         script=WORKFLOW_PATH / "src/mosdepth/v0.3.1/plot-dist.py",
     output:
-        protected(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "mosdepth" / "mosdepth.html"),
+        OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "mosdepth" / "mosdepth.html",
     message:
         "Running mosdepth plotting"
     singularity: 
@@ -156,8 +156,8 @@ rule indexcov:
         bam=[value["bam"] for value in SAMPLES_CONFIG.values()],
         bam_index=[value["bam"]+".bai" for value in SAMPLES_CONFIG.values()],
     output:
-        html=protected(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "indexcov" / "index.html"),
-        bed=protected(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "indexcov" / "indexcov-indexcov.bed.gz"),
+        html=OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "indexcov" / "index.html",
+        bed=OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "indexcov" / "indexcov-indexcov.bed.gz",
     message:
         "Running indexcov"
     log:
@@ -181,7 +181,7 @@ rule covviz:
         bed=OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "indexcov" / "indexcov-indexcov.bed.gz",
         ped=PEDIGREE_FPATH,
     output:
-        html=protected(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "covviz" / "covviz_report.html"),
+        html=OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "covviz" / "covviz_report.html",
     message:
         "Running covviz"
     log:

--- a/workflow/rules/relatedness_ancestry.smk
+++ b/workflow/rules/relatedness_ancestry.smk
@@ -5,7 +5,7 @@ rule somalier_extract:
         sites=config["datasets"]["somalier"]["sites"],
         ref_genome=config["datasets"]["ref"],
     output:
-        protected(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "extract" / "{sample}.somalier"),
+        OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "extract" / "{sample}.somalier",
     message:
         "Running somalier extract. Sample: {wildcards.sample}"
     singularity:
@@ -27,12 +27,10 @@ rule somalier_relate:
         extracted=expand(OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "extract" / "{sample}.somalier", sample=SAMPLES),
         ped=PEDIGREE_FPATH,
     output:
-        out=protected(
-            expand(
+        out=expand(
                 OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "relatedness" / "somalier.{ext}",
                 ext=["html", "pairs.tsv", "samples.tsv"],
-            )
-        ),
+            ),
     message:
         "Running somalier relate"
     singularity:
@@ -58,12 +56,10 @@ rule somalier_ancestry:
         labels_1kg=config["datasets"]["somalier"]["labels_1kg"],
         somalier_1kg_directory=config["datasets"]["somalier"]["somalier_1kg"],
     output:
-        out=protected(
-            expand(
+        out=expand(
                 OUT_DIR / PROJECT_LEVEL_QC_SUBDIR / "somalier" / "ancestry" / "somalier.somalier-ancestry.{ext}",
                 ext=["html", "tsv"],
-            )
-        ),
+            ),
     message:
         "Running somalier ancestry."
     singularity:


### PR DESCRIPTION
# Pull request

**Please add a clear description of what the PR is about:**

Removes write-protection for project-level QC files produced by quac. As quac can often be rerun with updated sample list, project-level QC files need to recreated; currently, the user who ran the quac earlier needs to delete those write-protected files to allow another user rerun quac for the same project. This PR keeps the write-protection for sample-level output but removes it for project-level output.

This PR fixes #106

------

**Please fill in the checklist below and comment as needed:**

- [x] Was code modified? Briefly describe. _Yes. See above._
- [x] Was documentation modified? Briefly describe. _No as it is not needed._
- [x] Is this a bug-fix? Briefly describe. _Yes. See above._
- [x] Is this a feature addition? Briefly describe. _No_
- [x] Did you modify QuaC-Watch config file? If so, did you modify multiqc template
  `configs/multiqc_config_template.jinja2` and script `src/quac_watch/create_mutliqc_configs.py` as necessary? _No_
- [x] Did you perform system-level testing manually, using `----cli_cluster_config` and `--snakemake_cluster_config`
  options, as described in the [documentation](https://quac.readthedocs.io/en/stable/system_testing/)? Did it pass
  completely? If not why? _Yes. It passed._
- [x] Updated `Changelog.md` file with change logs in recommended format?


## Anything else reviewer should know?

An unrelated change was made as part of this PR. Logic was modified to decide if testing_mode should be used when system testing is run. New logic decides based only on fastq filepaths; earlier it was ignoring fastq filepaths presumably due to change in config file structure used.